### PR TITLE
fix: support iteration index as strings

### DIFF
--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -1576,6 +1576,8 @@ public class Generator {
       return (Long) result;
     } else if (result instanceof Integer) {
       return ((Integer) result).longValue();
+    } else if (result instanceof String) {
+      return Long.parseLong((String) result);
     } else {
       throw new RuntimeException(String.format(
           "'%s' field of %s property must be an integral number, was %s instead",


### PR DESCRIPTION
Parse iteration index strings as longs