### PR TITLE
chore: update docker-compose.yml to docker compose v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   app:
     build:


### PR DESCRIPTION
Eliminamos el campo version en el docker-compose, era cosa de docker compose v1. Con v2 salta un warning:

```
WARN[0000] [...]/avro-random-generator/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```